### PR TITLE
Release v1.1.1: Hotfix map tile provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [v1.0.1 Release Notes](docs/releases/v1.0.1.md)
 - [v1.0.2 Release Notes](docs/releases/v1.0.2.md)
 - [v1.1.0 Release Notes](docs/releases/v1.1.0.md)
+- [v1.1.1 Release Notes](docs/releases/v1.1.1.md)
 
 ---
 

--- a/backend/ai-service/pom.xml
+++ b/backend/ai-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/api-service/pom.xml
+++ b/backend/api-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/backend/notification-service/pom.xml
+++ b/backend/notification-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -8,7 +8,7 @@
     <!-- ROOT POM -->
     <groupId>com.tripflow</groupId>
     <artifactId>tripflow-backend</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <name>TripFlow Backend</name>

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -1,0 +1,28 @@
+# 📦 TripFlow - Release v1.1.1
+
+---
+
+> **🧭 Summary**
+>
+> Patch release **1.1.1** of **TripFlow**. Hotfix for the map view: CartoDB dark tiles stopped rendering correctly, leaving the map blank. The tile provider has been switched to Stadia Maps (Stamen Toner Dark) with an adjusted tinting filter to keep the dark theme consistent. No application features change — this is a frontend bugfix release.
+
+---
+
+## 📄 Release Notes
+
+### 🐛 Bug Fixes
+
+- **Map tile provider**: switched from CartoDB `dark_all` to Stadia Maps `stamen_toner_dark`. The previous provider began returning empty tiles, breaking the map on all routes that use it.
+- **Tile tinting filter**: rebalanced the CSS filter on the Leaflet tile pane (`brightness` 1.2→0.5, `saturate` 2→1.75, `hue-rotate` 170°→175°) so the new tiles blend naturally into the dark theme without looking washed out.
+
+### 🏷️ Version
+
+- Frontend and all backend modules bumped to **1.1.1**.
+
+## 🔗 Links & Resources
+
+- 📂 [GitHub Repository](https://github.com/codeurjc-students/2025-TripFlow)
+- 🐳 [DockerHub - API Service](https://hub.docker.com/r/cub1z/tripflow-api-service)
+- 🐳 [DockerHub - AI Service](https://hub.docker.com/r/cub1z/tripflow-ai-service)
+- 🐳 [DockerHub - Notification Service](https://hub.docker.com/r/cub1z/tripflow-notification-service)
+- 🐳 [DockerHub - Frontend](https://hub.docker.com/r/cub1z/tripflow-frontend)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/src/components/map/LeafletMapView.tsx
+++ b/frontend/src/components/map/LeafletMapView.tsx
@@ -11,7 +11,7 @@ interface LeafletMapViewProps {
     className?: string;
 }
 
-const TILE_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
+const TILE_URL = "https://tiles.stadiamaps.com/tiles/stamen_toner_dark/{z}/{x}/{y}{r}.png";
 
 export default function LeafletMapView({
     bounds,

--- a/frontend/src/styles/components/map/MapTheme.module.css
+++ b/frontend/src/styles/components/map/MapTheme.module.css
@@ -8,7 +8,7 @@
 }
 
 .mapContainer :global(.leaflet-tile-pane) {
-    filter: brightness(1.2) sepia(0.5) hue-rotate(170deg) saturate(2);
+    filter: brightness(0.5) sepia(0.5) hue-rotate(175deg) saturate(1.75);
 }
 
 .mapContainer :global(.leaflet-control-container) {


### PR DESCRIPTION
# 📦 TripFlow - Release v1.1.1

---

> **🧭 Summary**
>
> Patch release **1.1.1** of **TripFlow**.
> Hotfix for the map view: CartoDB dark tiles stopped rendering correctly, leaving the map blank.
> The tile provider has been switched to Stadia Maps (Stamen Toner Dark) with an adjusted tinting filter to keep the dark theme consistent.
> No application features change — this is a frontend bugfix release.

---

## 📄 Release Notes

### 🐛 Bug Fixes

> **Map tile provider fix**
>
> - ✅ **Tile provider switched**: replaced CartoDB `dark_all` with Stadia Maps `stamen_toner_dark`. The previous provider began returning empty tiles, breaking the map on all routes that use it.
> - ✅ **Tinting filter rebalanced**: CSS filter on the Leaflet tile pane adjusted (`brightness` 1.2→0.5, `saturate` 2→1.75, `hue-rotate` 170°→175°) so the new tiles blend naturally into the dark theme.

### 🏷️ Version

> - ✅ Frontend and all backend modules bumped to **1.1.1**.

## ✅ Verification

- CI unit tests green on `develop`.

## 🔗 Links & Resources

- 📂 [Release Notes](docs/releases/v1.1.1.md)
- 📂 [GitHub Repository](https://github.com/codeurjc-students/2025-TripFlow)
- 🐳 [DockerHub - Frontend](https://hub.docker.com/r/cub1z/tripflow-frontend)