### PR TITLE
Release v1.1.2: Fix CSP for Stadia Maps tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [v1.0.2 Release Notes](docs/releases/v1.0.2.md)
 - [v1.1.0 Release Notes](docs/releases/v1.1.0.md)
 - [v1.1.1 Release Notes](docs/releases/v1.1.1.md)
+- [v1.1.2 Release Notes](docs/releases/v1.1.2.md)
 
 ---
 

--- a/backend/ai-service/pom.xml
+++ b/backend/ai-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/api-service/pom.xml
+++ b/backend/api-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/backend/notification-service/pom.xml
+++ b/backend/notification-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>com.tripflow</groupId>
         <artifactId>tripflow-backend</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
 	<groupId>com.tripflow</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -8,7 +8,7 @@
     <!-- ROOT POM -->
     <groupId>com.tripflow</groupId>
     <artifactId>tripflow-backend</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <name>TripFlow Backend</name>

--- a/docs/releases/v1.1.2.md
+++ b/docs/releases/v1.1.2.md
@@ -1,0 +1,27 @@
+# 📦 TripFlow - Release v1.1.2
+
+---
+
+> **🧭 Summary**
+>
+> Patch release **1.1.2** of **TripFlow**. Fixes a Content Security Policy issue introduced in v1.1.1: the new Stadia Maps tile provider was blocked by the `img-src` directive in nginx, leaving the map blank. No application features change — this is a frontend CSP hotfix.
+
+---
+
+## 📄 Release Notes
+
+### 🐛 Bug Fixes
+
+- **CSP img-src**: added `https://tiles.stadiamaps.com` to the Content Security Policy `img-src` directive in nginx. The v1.1.1 tile provider switch introduced a new external origin that was not whitelisted, causing the browser to block all map tile requests.
+
+### 🏷️ Version
+
+- Frontend and all backend modules bumped to **1.1.2**.
+
+## 🔗 Links & Resources
+
+- 📂 [GitHub Repository](https://github.com/codeurjc-students/2025-TripFlow)
+- 🐳 [DockerHub - API Service](https://hub.docker.com/r/cub1z/tripflow-api-service)
+- 🐳 [DockerHub - AI Service](https://hub.docker.com/r/cub1z/tripflow-ai-service)
+- 🐳 [DockerHub - Notification Service](https://hub.docker.com/r/cub1z/tripflow-notification-service)
+- 🐳 [DockerHub - Frontend](https://hub.docker.com/r/cub1z/tripflow-frontend)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,7 +22,7 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' blob: data: https://images.unsplash.com; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' blob: data: https://images.unsplash.com https://tiles.stadiamaps.com; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         location / {
             # $uri/index.html serves prerendered pages (e.g. /help) with no

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
# 📦 TripFlow - Release v1.1.2

---

> **🧭 Summary**
>
> Patch release **1.1.2** of **TripFlow**.
> Fixes a Content Security Policy issue introduced in v1.1.1: the new Stadia Maps tile provider was blocked by the `img-src` directive in nginx, leaving the map blank.
> No application features change — this is a frontend CSP hotfix.

---

## 📄 Release Notes

### 🐛 Bug Fixes

> **CSP img-src fix**
>
> - ✅ **CSP img-src updated**: added `https://tiles.stadiamaps.com` to the Content Security Policy `img-src` directive in nginx. The v1.1.1 tile provider switch introduced a new external origin that was not whitelisted, causing the browser to block all map tile requests.

### 🏷️ Version

> - ✅ Frontend and all backend modules bumped to **1.1.2**.

## ✅ Verification

- CI unit tests green on `develop`.

## 🔗 Links & Resources

- 📂 [Release Notes](docs/releases/v1.1.2.md)
- 📂 [GitHub Repository](https://github.com/codeurjc-students/2025-TripFlow)
- 🐳 [DockerHub - Frontend](https://hub.docker.com/r/cub1z/tripflow-frontend)